### PR TITLE
Fixes for two crashes

### DIFF
--- a/src/DirectionalMovementHandler.cpp
+++ b/src/DirectionalMovementHandler.cpp
@@ -1056,12 +1056,13 @@ std::vector<RE::ActorHandle> DirectionalMovementHandler::FindCloseActor(float di
 
 RE::ActorHandle DirectionalMovementHandler::FindTarget(float a_distance)
 {
-	auto crosshairRef = Events::CrosshairRefManager::GetSingleton()->GetCachedRef();
-	if (crosshairRef)
+	if (auto crosshairRef = Events::CrosshairRefManager::GetSingleton()->GetCachedRef())
 	{
-		auto crosshairActor = RE::ActorPtr(crosshairRef.get()->As<RE::Actor>());
-		if (crosshairActor && crosshairActor != _target.get() && IsActorValidTarget(crosshairActor)) {
-			return crosshairActor->GetHandle();
+		if (auto crosshairRefPtr = crosshairRef.get()) {
+			auto crosshairActor = RE::ActorPtr(crosshairRefPtr->As<RE::Actor>());
+			if (crosshairActor && crosshairActor != _target.get() && IsActorValidTarget(crosshairActor)) {
+				return crosshairActor->GetHandle();
+			}
 		}
 	}
 	

--- a/src/DirectionalMovementHandler.cpp
+++ b/src/DirectionalMovementHandler.cpp
@@ -503,6 +503,7 @@ void DirectionalMovementHandler::UpdateRotation()
 		// Get the current movement type
 		RE::BSTSmartPointer<RE::BSAnimationGraphManager> animationGraphManagerPtr;
 		playerCharacter->GetAnimationGraphManager(animationGraphManagerPtr);
+		if (!animationGraphManagerPtr) return;
 
 		RE::BSFixedString string;
 


### PR DESCRIPTION
This is a PR to fix two CTD I encountered while using the mod with Skyrim SE 1.5.73.

The first commit fixes the occasional crash when targeting because the stored reference to the crosshair apparently becomes invalid. The existing code checks only that the reference exists, but not that the referent is valid (i.e. that the smart pointer derived from the stale reference is valid). This fix adds an additional check on the smart pointer.

The second commit fixes a crash I encountered when in combat. Apparently the code tries to get the Animation Graph Manager for the player character. Unfortunately, apparently this doesn't always work (?) and so the pointer remains unset and then unconditionally dereferenced. This fix checks the pointer and returns early if it's not set.

Feel free to do with these fixes as you wish! :)