### PR TITLE
Fix wrong moving direction during switching weapons.

### DIFF
--- a/src/DirectionalMovementHandler.cpp
+++ b/src/DirectionalMovementHandler.cpp
@@ -692,7 +692,7 @@ bool DirectionalMovementHandler::GetFreeCameraEnabled() const
 	auto playerCharacter = RE::PlayerCharacter::GetSingleton();
 	if (playerCharacter)
 	{
-		return playerCharacter->IsWeaponDrawn() ? _bDirectionalMovementDrawn : _bDirectionalMovementSheathed;
+		return playerCharacter->GetWeaponState() == RE::WEAPON_STATE::kSheathed ? _bDirectionalMovementSheathed : _bDirectionalMovementDrawn;
 	}
 
 	return false;


### PR DESCRIPTION
If you disable 360 degree movement in weapon drawn state, you will have an opposite wrong moving direction during the seconds you switching weapon. Change this line of code to this could fix that.