### PR TITLE
Fix cone projectile aiming in third person (free aim and target lock)

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -948,6 +948,9 @@ namespace Hooks
 				case RE::FormType::ProjectileMissile:
 					aimType = Settings::uTargetLockMissileAimType;
 					break;
+				case RE::FormType::ProjectileCone:
+					aimType = Settings::uTargetLockMissileAimType;
+					break;
 				default:
 					aimType = TargetLockProjectileAimType::kFreeAim;
 				}
@@ -1066,6 +1069,13 @@ namespace Hooks
 	void ProjectileHook::GetLinearVelocityMissile(RE::Projectile* a_this, RE::NiPoint3& a_outVelocity)
 	{
 		_GetLinearVelocityMissile(a_this, a_outVelocity);
+
+		ProjectileAimSupport(a_this);
+	}
+
+	void ProjectileHook::GetLinearVelocityCone(RE::Projectile* a_this, RE::NiPoint3& a_outVelocity)
+	{
+		_GetLinearVelocityCone(a_this, a_outVelocity);
 
 		ProjectileAimSupport(a_this);
 	}

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -1226,6 +1226,93 @@ namespace Hooks
 
 					linearVelocity = direction * velocityScalar;
 				}
+			} else if (a_this->formType.get() == RE::FormType::ProjectileCone && directionalMovementHandler->IsFreeCamera() &&
+					   (!directionalMovementHandler->HasTargetLocked() || Settings::uTargetLockMissileAimType == TargetLockProjectileAimType::kFreeAim)) {
+				// The game launches cone projectiles with the shooter's body pitch instead of the camera aim pitch,
+				// so they miss the crosshair while the third person free camera is active (the character's pitch is
+				// not synced to the camera). Re-aim them along the camera ray. Only relevant for long range cone
+				// projectiles used by some spell mods, e.g. Astral Magic 2.
+				auto playerCamera = RE::PlayerCamera::GetSingleton();
+				if (playerCamera->currentState && playerCamera->currentState->id == RE::CameraState::kThirdPerson) {
+					constexpr RE::NiPoint3 forwardVector{ 0.f, 1.f, 0.f };
+					auto thirdPersonState = static_cast<RE::ThirdPersonState*>(playerCamera->currentState.get());
+					RE::NiQuaternion cameraRotation;
+					thirdPersonState->GetRotation(cameraRotation);
+
+					auto cameraForwardVector = RotateVector(forwardVector, cameraRotation);
+
+					cameraForwardVector.Unitize();
+
+					auto cameraPos = playerCamera->cameraRoot->world.translate;
+
+					RE::NiPoint3 rayStart = cameraPos;
+					RE::NiPoint3 rayEnd = cameraPos + cameraForwardVector * 5000.f;
+					RE::NiPoint3 hitPos = rayEnd;
+
+					RE::NiPoint3 cameraToPlayer = playerCamera->cameraTarget.get()->GetPosition() - cameraPos;
+					RE::NiPoint3 cameraToTarget = rayEnd - cameraPos;
+					RE::NiPoint3 projected = Project(cameraToPlayer, cameraToTarget);
+					RE::NiPoint3 projectedPos = RE::NiPoint3(projected.x + cameraPos.x, projected.y + cameraPos.y, projected.z + cameraPos.z);
+					rayStart = projectedPos;
+
+					uint16_t playerCollisionGroup = 0;
+
+					auto playerCharacter = RE::PlayerCharacter::GetSingleton();
+					if (auto playerBody = playerCharacter->Get3D()) {
+						if (auto collisionObject = playerBody->GetCollisionObject()) {
+							if (auto rigidBody = collisionObject->GetRigidBody()) {
+								playerCollisionGroup = static_cast<RE::hkpEntity*>(rigidBody->referencedObject.get())->collidable.broadPhaseHandle.collisionFilterInfo >> 16;
+							}
+						}
+					}
+
+					float bhkWorldScale = *g_worldScale;
+
+					collector.Reset();
+					RE::hkpWorldRayCastInput raycastInput;
+					raycastInput.filterInfo = ((uint32_t)playerCollisionGroup << 16) | 0x28;
+					raycastInput.from.quad = _mm_setr_ps(rayStart.x * bhkWorldScale, rayStart.y * bhkWorldScale, rayStart.z * bhkWorldScale, 0.f);
+					raycastInput.to.quad = _mm_setr_ps(rayEnd.x * bhkWorldScale, rayEnd.y * bhkWorldScale, rayEnd.z * bhkWorldScale, 0.f);
+					auto world = playerCharacter->parentCell->GetbhkWorld();
+					world->worldLock.LockForRead();
+					CastRay(world->GetWorld2(), raycastInput, collector);
+					world->worldLock.UnlockForRead();
+					if (collector.doesHitExist) {
+						auto distance = rayEnd - rayStart;
+						hitPos = rayStart + (distance * collector.closestHitInfo.hitFraction);
+					}
+
+					RE::NiPoint3 direction = hitPos - a_this->data.location;
+					direction.Unitize();
+
+					float rotationX, rotationZ;
+
+					rotationX = atan2(-direction.z, std::sqrtf(direction.x * direction.x + direction.y * direction.y));
+					rotationZ = atan2(direction.x, direction.y);
+
+					if (rotationZ < 0.0) {
+						rotationZ += PI;
+					}
+
+					if (direction.x < 0.0) {
+						rotationZ += PI;
+					}
+
+					a_this->data.angle.x = rotationX;
+					a_this->data.angle.z = rotationZ;
+
+					auto projectileNode = a_this->Get3D();
+					if (projectileNode) {
+						SetRotationMatrix(projectileNode->local.rotate, direction.x, direction.y, direction.z);
+					}
+
+					// no f3PArrowTiltUpAngle tilt here: unlike arrows, cone projectiles get no engine side
+					// crosshair correction that would compensate for it, so the exact ray direction is what we want
+					auto& linearVelocity = a_this->GetProjectileRuntimeData().linearVelocity;
+					float velocityScalar = linearVelocity.Length();
+
+					linearVelocity = direction * velocityScalar;
+				}
 			}
 		}
 	}

--- a/src/Hooks.h
+++ b/src/Hooks.h
@@ -243,9 +243,11 @@ namespace Hooks
 			REL::Relocation<std::uintptr_t> ArrowProjectileVtbl{ RE::VTABLE_ArrowProjectile[0] };			// 1676318
 			REL::Relocation<std::uintptr_t> MissileProjectileVtbl{ RE::VTABLE_MissileProjectile[0] };		// 167AE78
 			REL::Relocation<std::uintptr_t> BeamProjectileVtbl{ RE::VTABLE_BeamProjectile[0] };          // 1677660
+			REL::Relocation<std::uintptr_t> ConeProjectileVtbl{ RE::VTABLE_ConeProjectile[0] };
 			_GetLinearVelocityProjectile = ProjectileVtbl.write_vfunc(0x86, GetLinearVelocityProjectile);
 			_GetLinearVelocityArrow = ArrowProjectileVtbl.write_vfunc(0x86, GetLinearVelocityArrow);
 			_GetLinearVelocityMissile = MissileProjectileVtbl.write_vfunc(0x86, GetLinearVelocityMissile);
+			_GetLinearVelocityCone = ConeProjectileVtbl.write_vfunc(0x86, GetLinearVelocityCone);
 
 			auto& trampoline = SKSE::GetTrampoline();
 			REL::Relocation<uintptr_t> hook{ RELOCATION_ID(43030, 44222) };  // 754820, 7821A0
@@ -258,12 +260,14 @@ namespace Hooks
 		static void GetLinearVelocityProjectile(RE::Projectile* a_this, RE::NiPoint3& a_outVelocity);
 		static void GetLinearVelocityArrow(RE::Projectile* a_this, RE::NiPoint3& a_outVelocity);
 		static void GetLinearVelocityMissile(RE::Projectile* a_this, RE::NiPoint3& a_outVelocity);
+		static void GetLinearVelocityCone(RE::Projectile* a_this, RE::NiPoint3& a_outVelocity);
 		static bool Func183(RE::Projectile* a_this);
 		static void InitProjectile(RE::Projectile* a_this);
 
 		static inline REL::Relocation<decltype(GetLinearVelocityProjectile)> _GetLinearVelocityProjectile;
 		static inline REL::Relocation<decltype(GetLinearVelocityArrow)> _GetLinearVelocityArrow;
 		static inline REL::Relocation<decltype(GetLinearVelocityMissile)> _GetLinearVelocityMissile;
+		static inline REL::Relocation<decltype(GetLinearVelocityCone)> _GetLinearVelocityCone;
 		static inline REL::Relocation<decltype(InitProjectile)> _InitProjectile;
 	};
 


### PR DESCRIPTION
Addresses #6.

Two independent commits, intentionally kept separate so they can be cherry-picked individually:

## 1. `Support cone projectiles in target lock aim types`

Minimal extension of the existing pattern: installs the `GetLinearVelocity` hook on `RE::VTABLE_ConeProjectile[0]` (cones have their own vtable, so the base `Projectile` hook never fires for them) and maps `FormType::ProjectileCone` to `uTargetLockMissileAimType` in `ProjectileAimSupport`. With this, predict and homing behave for cone projectiles the way they already do for missiles. No new settings and no MCM changes.

## 2. `Aim player cone projectiles at the crosshair in third person`

Fixes the free aim case. The engine derives the launch direction of player-fired missiles/arrows/beams from the camera, but cone projectiles launch with the shooter's body pitch. Since the free camera keeps camera pitch in `freeRotation.y` without syncing the character's pitch (`UpdateFacingCrosshair` transfers yaw only), cones miss the crosshair, with error growing with distance.

The fix re-aims player-fired cone projectiles along the camera-crosshair raycast in `InitProjectile`, reusing the exact approach (and constants) of the existing mounted aiming block, gated to: player shooter, cone form type, `IsFreeCamera()`, third person camera state, and either no target lock or lock with the free aim setting. Notes:

- The `f3PArrowTiltUpAngle` tilt from the mounted block is intentionally omitted: cones get no engine-side crosshair correction that would compensate for the tilt, so the exact ray direction is what should be flown.
- Vanilla-castable cones (Flames etc.) are short range spray effects where this is invisible; the case that matters is long-range cone projectiles used by spell mods for their pierce-through-actors behavior (Astral Magic 2's Astral Spear line, Piercing Expert Spells, both with 10k-90k unit ranges).

## Testing status

Full disclosure: I authored this against the patterns already in the codebase and it compiles clean in CI, but I have not yet done an in-game runtime test of these builds. I did verify the diagnosis in-game extensively (cone spells miss high in third person free aim and target lock, are accurate in first person, and accurate with TDM removed - details in #6). Happy to run the CI artifact through in-game testing if you'd like that before considering this, or feel free to treat this PR as a reference implementation for #6 and rework it as you see fit.
